### PR TITLE
Fixing issue where other plugins being unable to fetch their own driver 

### DIFF
--- a/src/me/Cutiemango/MangoQuest/Main.java
+++ b/src/me/Cutiemango/MangoQuest/Main.java
@@ -170,6 +170,7 @@ public class Main extends JavaPlugin {
 						Collections.list(DriverManager.getDrivers()).forEach(driver -> {
 							try {
 								DriverManager.deregisterDriver(driver);
+								DriverManager.registerDriver(driver);
 							} catch (SQLException e) {
 								ChatManager.logCmd(Level.SEVERE, "An error occured while deregistering sql drivers!");
 								e.printStackTrace();


### PR DESCRIPTION
### Known Problem

- Since we iterate over the whole driver list,its entirely possible that we may have deregistered other plugins' sql drivers

### Proposed Solution

- register driver back in after we deregister the driver


In order to know that registering the driver would truly solve the problem,we would need to take a swift look at the source code

### Detailed Problem Investigation
**Too Long Dont Read:**
The solution will work as the driver reregistered does not depend on plugin instance to work but only correspond to the user credentials,sql database and properties etc.The registered driver is the same instance as the deregistered and will have the same credentials and properties.

The problem occurs because of the following code
  private static Connection getConnection(
        String url, java.util.Properties info, Class<?> caller) throws SQLException {
        /*
         * When callerCl is null, we should check the application's
         * (which is invoking this class indirectly)
         * classloader, so that the JDBC driver class outside rt.jar
         * can be loaded from here.
         */
        ClassLoader callerCL = caller != null ? caller.getClassLoader() : null;
        synchronized(DriverManager.class) {
            // synchronize loading of the correct classloader.
            if (callerCL == null) {
                callerCL = Thread.currentThread().getContextClassLoader();
            }
        }

        if(url == null) {
            throw new SQLException("The url cannot be null", "08001");
        }

        println("DriverManager.getConnection(\"" + url + "\")");

        // Walk through the loaded registeredDrivers attempting to make a connection.
        // Remember the first exception that gets raised so we can reraise it.
        SQLException reason = null;

        for(DriverInfo aDriver : registeredDrivers) {
            // If the caller does not have permission to load the driver then
            // skip it.
            if(isDriverAllowed(aDriver.driver, callerCL)) { <--1
                try {
                    println("    trying " + aDriver.driver.getClass().getName());
                    Connection con = aDriver.driver.connect(url, info); <--2
                    if (con != null) {
                        // Success!
                        println("getConnection returning " + aDriver.driver.getClass().getName());
                        return (con);
                    }
                } catch (SQLException ex) {
                    if (reason == null) {
                        reason = ex;
                    }
                }

            } else {
                println("    skipping: " + aDriver.getClass().getName());
            }

        }

        // if we got here nobody could connect.
        if (reason != null)    {
            println("getConnection failed: " + reason);
            throw reason;
        }

        println("getConnection: no suitable driver found for "+ url);
        throw new SQLException("No suitable driver found for "+ url, "08001");
    }


}

The error is caused by aDriver.driver being deregistered in -->2 since obviously we deregistered it.So we just have to register it back in with registerDriver which creates another aDriver instance in registered drivers
even one of the registered aDriver instance having null aDriver.driver,the newly registered driver in aDriver.driver in another iteration will still ensure the registered driver to manage the connection.What we are concerned about is if the classloader of mangoquest will take away the permission for other plugins to use the registered driver (in --> 1).Upon further investigation,the permission is merely checking if the specified driver class is present in the classloader.Since all of the plugins use default drivers,so other plugins will definitely have such "permission" to use the driver.The driver will not fail to connect too as with the same credentials and user data the driver will not cease to work
as long as you have the same credentials 


So this totally proves that registering the driver back in will restore the driver for other plugins.
