### PR TITLE
Fixing item delivery detection failure

### DIFF
--- a/src/me/Cutiemango/MangoQuest/data/QuestPlayerData.java
+++ b/src/me/Cutiemango/MangoQuest/data/QuestPlayerData.java
@@ -469,10 +469,16 @@ public class QuestPlayerData
 
 	public boolean deliverItem(NPC npc) {
 		AtomicReference<Pair<QuestProgress, QuestObjectProgress>> any = new AtomicReference<>();
-		currentQuests.stream().filter(qp -> checkPlayerInWorld(qp.getQuest())).forEach(qp -> {
-			Optional<QuestObjectProgress> obj = qp.getCurrentObjects().stream().filter(qop -> checkItem(qop, npc)).findFirst();
-			obj.ifPresent(qop -> any.set(new Pair<>(qp, qop)));
-		});
+		for(QuestProgress qp:currentQuests) {
+			if(checkPlayerInWorld(qp.getQuest())) {
+				for(QuestObjectProgress qop:qp.getCurrentObjects()) {
+					if(checkItem(qop,npc)) {
+						any.set(new Pair<>(qp,qop));
+						break;
+					}
+				}
+			}
+		}
 		if (any.get() != null) {
 			Pair<QuestProgress, QuestObjectProgress> pair = any.get();
 			checkFinished(pair.getKey(), pair.getValue());
@@ -625,15 +631,15 @@ public class QuestPlayerData
 	public String getQuestDisplayFormat(Quest q) {
 		if (canTake(q, false)) {
 			if (hasFinished(q))
-				return I18n.locMsg("QuestGUI.RedoableQuestSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
+				return I18n.locMsg("QuestGUI.RedoableQuestSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
 			else
-				return I18n.locMsg("QuestGUI.NewQuestSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
+				return I18n.locMsg("QuestGUI.NewQuestSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
 		} else {
 			for (QuestObjectProgress op : getProgress(q).getCurrentObjects()) {
 				if (op.getObject() instanceof QuestObjectTalkToNPC && !op.isFinished())
-					return I18n.locMsg("QuestGUI.QuestReturnSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
+					return I18n.locMsg("QuestGUI.QuestReturnSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
 			}
-			return I18n.locMsg("QuestGUI.QuestDoingSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
+			return I18n.locMsg("QuestGUI.QuestDoingSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
 		}
 	}
 

--- a/src/me/Cutiemango/MangoQuest/data/QuestPlayerData.java
+++ b/src/me/Cutiemango/MangoQuest/data/QuestPlayerData.java
@@ -631,15 +631,15 @@ public class QuestPlayerData
 	public String getQuestDisplayFormat(Quest q) {
 		if (canTake(q, false)) {
 			if (hasFinished(q))
-				return I18n.locMsg("QuestGUI.RedoableQuestSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
+				return I18n.locMsg("QuestGUI.RedoableQuestSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
 			else
-				return I18n.locMsg("QuestGUI.NewQuestSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
+				return I18n.locMsg("QuestGUI.NewQuestSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
 		} else {
 			for (QuestObjectProgress op : getProgress(q).getCurrentObjects()) {
 				if (op.getObject() instanceof QuestObjectTalkToNPC && !op.isFinished())
-					return I18n.locMsg("QuestGUI.QuestReturnSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
+					return I18n.locMsg("QuestGUI.QuestReturnSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
 			}
-			return I18n.locMsg("QuestGUI.QuestDoingSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
+			return I18n.locMsg("QuestGUI.QuestDoingSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
 		}
 	}
 


### PR DESCRIPTION
### ISSUE
Detailed explanation:
When there is one or more similar items within multiple quests within the same npc,the checkItem(qop,npc) is called multiple times which causes the progress being set to complete when enough items are delivered but at the same time not updating the objective completion because checkFinished is callled only once,
causing the progress display to glitch and showing eg (deliver dead_bush to abc 15/15) but with no strikethrough symbol indicating it to be completed

### Cause:
the filter function used in the stream api sets progress while filtering which means other items may match 
with the new loop function,it will stop calling multiple checkItem and only call once checkItem when it finds the first match.
