### PR TITLE
Fixing Item delivery failure + Finish check failure + Large Item Crashes Quest Editor Fix

### DIFF
--- a/src/me/Cutiemango/MangoQuest/book/InteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/InteractiveText.java
@@ -1,5 +1,8 @@
 package me.Cutiemango.MangoQuest.book;
 
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
 import me.Cutiemango.MangoQuest.data.QuestPlayerData;
 import me.Cutiemango.MangoQuest.manager.QuestChatManager;
 import me.Cutiemango.MangoQuest.model.Quest;
@@ -8,8 +11,6 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
-import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.NotNull;
 
 public class InteractiveText
 {
@@ -23,7 +24,9 @@ public class InteractiveText
 
 	// similar to showItem
 	public InteractiveText(@NotNull ItemStack item) {
+		if(!this.getClass().isAssignableFrom(ItemSafeInteractiveText.class)) {
 		text = TextComponentFactory.convertItemHoverEvent(item, false);
+		}
 	}
 
 	private TextComponent text;

--- a/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
@@ -1,10 +1,11 @@
 package me.Cutiemango.MangoQuest.book;
 
 import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
@@ -13,13 +14,14 @@ import me.Cutiemango.MangoQuest.data.QuestPlayerData;
 import me.Cutiemango.MangoQuest.manager.QuestChatManager;
 import me.Cutiemango.MangoQuest.model.Quest;
 import net.citizensnpcs.api.npc.NPC;
+import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 
 public class ItemSafeInteractiveText extends InteractiveText{
-	public static final int MAX_LENGTH = 65535;
+	public static final int MAX_LENGTH =  800;
 	private TextComponent text;
 	
 	public ItemSafeInteractiveText(TextComponent t) {
@@ -35,7 +37,8 @@ public class ItemSafeInteractiveText extends InteractiveText{
 	public ItemSafeInteractiveText(@NotNull ItemStack item) {
 		super(item);
 		int bytelen = 0;
-		ItemMeta meta = item.getItemMeta();
+		ItemStack itemclone = item.clone();
+		ItemMeta meta = itemclone.getItemMeta();
 		if (meta.hasDisplayName()) {
 			try {
 				bytelen += meta.getDisplayName().getBytes("UTF-8").length;
@@ -47,27 +50,32 @@ public class ItemSafeInteractiveText extends InteractiveText{
 		if (meta.hasLore()) {
 			List<String> temp = meta.getLore();
 			int index = -1;
-			List<Integer> indextoremove = new ArrayList<Integer>();
 			for (String t : temp) {
 				index++;
+			
 				try {
 					int length = t.getBytes("UTF-8").length;
 					if(bytelen+length > MAX_LENGTH) {
-						indextoremove.add(length);
+						index--;
 						break;
 					}
 				    bytelen+=length;
 				} catch (UnsupportedEncodingException e) {
-                    indextoremove.add(index);
     				QuestChatManager.logCmd(Level.WARNING, " Cannot get item lore byte length in utf 8");
 					e.printStackTrace();
 				}
-
 			}
+			temp = temp.subList(0, index);
+			temp.add(ChatColor.translateAlternateColorCodes('&', "&2..................."));
 			meta.setLore(temp);
 		}
-		item.setItemMeta(meta);
-		text = TextComponentFactory.convertItemHoverEvent(item, false);
+		itemclone.setItemMeta(meta);
+		text = TextComponentFactory.convertItemHoverEvent(itemclone, false);
+		if(text != null) {
+			for(Player p:Bukkit.getOnlinePlayers()) { 
+				p.spigot().sendMessage(text);
+			}
+		}
 	}
 
 
@@ -82,7 +90,8 @@ public class ItemSafeInteractiveText extends InteractiveText{
 
 	public ItemSafeInteractiveText showItem(@NotNull ItemStack item) {
 		int bytelen = 0;
-		ItemMeta meta = item.getItemMeta();
+		ItemStack itemclone = item.clone();
+		ItemMeta meta = itemclone.getItemMeta();
 		if (meta.hasDisplayName()) {
 			try {
 				bytelen += meta.getDisplayName().getBytes("UTF-8").length;
@@ -94,27 +103,31 @@ public class ItemSafeInteractiveText extends InteractiveText{
 		if (meta.hasLore()) {
 			List<String> temp = meta.getLore();
 			int index = -1;
-			List<Integer> indextoremove = new ArrayList<Integer>();
 			for (String t : temp) {
 				index++;
+			
 				try {
 					int length = t.getBytes("UTF-8").length;
 					if(bytelen+length > MAX_LENGTH) {
-						indextoremove.add(length);
+
+						index--;
 						break;
 					}
 				    bytelen+=length;
 				} catch (UnsupportedEncodingException e) {
-                    indextoremove.add(index);
     				QuestChatManager.logCmd(Level.WARNING, " Cannot get item lore byte length in utf 8");
 					e.printStackTrace();
 				}
+				
 
 			}
+			temp = temp.subList(0, index);
 			meta.setLore(temp);
+			
 		}
-		item.setItemMeta(meta);
-		text.addExtra(TextComponentFactory.convertItemHoverEvent(item, false));
+
+		itemclone.setItemMeta(meta);
+		text = TextComponentFactory.convertItemHoverEvent(itemclone, false);
 		return this;
 	}
 

--- a/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
@@ -71,11 +71,6 @@ public class ItemSafeInteractiveText extends InteractiveText{
 		}
 		itemclone.setItemMeta(meta);
 		text = TextComponentFactory.convertItemHoverEvent(itemclone, false);
-		if(text != null) {
-			for(Player p:Bukkit.getOnlinePlayers()) { 
-				p.spigot().sendMessage(text);
-			}
-		}
 	}
 
 

--- a/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
@@ -4,8 +4,6 @@ import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.logging.Level;
 
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;

--- a/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
@@ -1,0 +1,149 @@
+package me.Cutiemango.MangoQuest.book;
+
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
+
+import me.Cutiemango.MangoQuest.data.QuestPlayerData;
+import me.Cutiemango.MangoQuest.manager.QuestChatManager;
+import me.Cutiemango.MangoQuest.model.Quest;
+import net.citizensnpcs.api.npc.NPC;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+
+public class ItemSafeInteractiveText extends InteractiveText{
+	public static final int MAX_LENGTH = 65535;
+	private TextComponent text;
+	
+	public ItemSafeInteractiveText(TextComponent t) {
+		super(t);
+		text = t;
+	}
+
+	public ItemSafeInteractiveText(String s) {
+		this(new TextComponent(TextComponent.fromLegacyText(QuestChatManager.translateColor(s))));
+	}
+
+	// similar to showItem
+	public ItemSafeInteractiveText(@NotNull ItemStack item) {
+		super(item);
+		int bytelen = 0;
+		ItemMeta meta = item.getItemMeta();
+		if (meta.hasDisplayName()) {
+			try {
+				bytelen += meta.getDisplayName().getBytes("UTF-8").length;
+			} catch (UnsupportedEncodingException e) {
+				QuestChatManager.logCmd(Level.WARNING, " Cannot get item display name byte length in utf 8");
+				e.printStackTrace();
+			}
+		}
+		if (meta.hasLore()) {
+			List<String> temp = meta.getLore();
+			int index = -1;
+			List<Integer> indextoremove = new ArrayList<Integer>();
+			for (String t : temp) {
+				index++;
+				try {
+					int length = t.getBytes("UTF-8").length;
+					if(bytelen+length > MAX_LENGTH) {
+						indextoremove.add(length);
+						break;
+					}
+				    bytelen+=length;
+				} catch (UnsupportedEncodingException e) {
+                    indextoremove.add(index);
+    				QuestChatManager.logCmd(Level.WARNING, " Cannot get item lore byte length in utf 8");
+					e.printStackTrace();
+				}
+
+			}
+			meta.setLore(temp);
+		}
+		item.setItemMeta(meta);
+		text = TextComponentFactory.convertItemHoverEvent(item, false);
+	}
+
+
+
+	// "/" needed.
+	public ItemSafeInteractiveText clickCommand(String cmd) {
+		if (!cmd.startsWith("/"))
+			cmd = "/" + cmd;
+		text.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, cmd));
+		return this;
+	}
+
+	public ItemSafeInteractiveText showItem(@NotNull ItemStack item) {
+		int bytelen = 0;
+		ItemMeta meta = item.getItemMeta();
+		if (meta.hasDisplayName()) {
+			try {
+				bytelen += meta.getDisplayName().getBytes("UTF-8").length;
+			} catch (UnsupportedEncodingException e) {
+				QuestChatManager.logCmd(Level.WARNING, " Cannot get item display name byte length in utf 8");
+				e.printStackTrace();
+			}
+		}
+		if (meta.hasLore()) {
+			List<String> temp = meta.getLore();
+			int index = -1;
+			List<Integer> indextoremove = new ArrayList<Integer>();
+			for (String t : temp) {
+				index++;
+				try {
+					int length = t.getBytes("UTF-8").length;
+					if(bytelen+length > MAX_LENGTH) {
+						indextoremove.add(length);
+						break;
+					}
+				    bytelen+=length;
+				} catch (UnsupportedEncodingException e) {
+                    indextoremove.add(index);
+    				QuestChatManager.logCmd(Level.WARNING, " Cannot get item lore byte length in utf 8");
+					e.printStackTrace();
+				}
+
+			}
+			meta.setLore(temp);
+		}
+		item.setItemMeta(meta);
+		text.addExtra(TextComponentFactory.convertItemHoverEvent(item, false));
+		return this;
+	}
+
+	public ItemSafeInteractiveText showText(String s) {
+		text.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+				new BaseComponent[] { new TextComponent(QuestChatManager.translateColor(s)) }));
+		return this;
+	}
+
+	public ItemSafeInteractiveText showNPCInfo(@NotNull NPC npc) {
+		text.addExtra(TextComponentFactory.convertLocHoverEvent(npc.getName(), npc.getStoredLocation(), false));
+		return this;
+	}
+
+	// display: quest's displayName
+	// hover: "click to view"
+	public ItemSafeInteractiveText showQuest(Quest q) {
+		text = TextComponentFactory.convertViewQuest(q);
+		return this;
+	}
+
+	// display: quest's displayName
+	// hover: requirement message
+	public ItemSafeInteractiveText showRequirement(QuestPlayerData qd, Quest q) {
+		text = TextComponentFactory.convertRequirement(qd, q);
+		return this;
+	}
+
+	public TextComponent get() {
+		return text;
+	}
+}

--- a/src/me/Cutiemango/MangoQuest/data/QuestPlayerData.java
+++ b/src/me/Cutiemango/MangoQuest/data/QuestPlayerData.java
@@ -469,10 +469,16 @@ public class QuestPlayerData
 
 	public boolean deliverItem(NPC npc) {
 		AtomicReference<Pair<QuestProgress, QuestObjectProgress>> any = new AtomicReference<>();
-		currentQuests.stream().filter(qp -> checkPlayerInWorld(qp.getQuest())).forEach(qp -> {
-			Optional<QuestObjectProgress> obj = qp.getCurrentObjects().stream().filter(qop -> checkItem(qop, npc)).findFirst();
-			obj.ifPresent(qop -> any.set(new Pair<>(qp, qop)));
-		});
+		for(QuestProgress qp:currentQuests) {
+			if(checkPlayerInWorld(qp.getQuest())) {
+				for(QuestObjectProgress qop:qp.getCurrentObjects()) {
+					if(checkItem(qop,npc)) {
+						any.set(new Pair<>(qp,qop));
+						break;
+					}
+				}
+			}
+		}
 		if (any.get() != null) {
 			Pair<QuestProgress, QuestObjectProgress> pair = any.get();
 			checkFinished(pair.getKey(), pair.getValue());
@@ -625,15 +631,15 @@ public class QuestPlayerData
 	public String getQuestDisplayFormat(Quest q) {
 		if (canTake(q, false)) {
 			if (hasFinished(q))
-				return I18n.locMsg("QuestGUI.RedoableQuestSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
+				return I18n.locMsg("QuestGUI.RedoableQuestSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
 			else
-				return I18n.locMsg("QuestGUI.NewQuestSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
+				return I18n.locMsg("QuestGUI.NewQuestSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
 		} else {
 			for (QuestObjectProgress op : getProgress(q).getCurrentObjects()) {
 				if (op.getObject() instanceof QuestObjectTalkToNPC && !op.isFinished())
-					return I18n.locMsg("QuestGUI.QuestReturnSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
+					return I18n.locMsg("QuestGUI.QuestReturnSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
 			}
-			return I18n.locMsg("QuestGUI.QuestDoingSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
+			return I18n.locMsg("QuestGUI.QuestDoingSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
 		}
 	}
 

--- a/src/me/Cutiemango/MangoQuest/data/QuestPlayerData.java
+++ b/src/me/Cutiemango/MangoQuest/data/QuestPlayerData.java
@@ -471,6 +471,9 @@ public class QuestPlayerData
 		AtomicReference<Pair<QuestProgress, QuestObjectProgress>> any = new AtomicReference<>();
 		for(QuestProgress qp:currentQuests) {
 			if(checkPlayerInWorld(qp.getQuest())) {
+				if(qp.checkIfNextStage()){
+				  continue;
+				}
 				for(QuestObjectProgress qop:qp.getCurrentObjects()) {
 					if(checkItem(qop,npc)) {
 						any.set(new Pair<>(qp,qop));

--- a/src/me/Cutiemango/MangoQuest/data/QuestPlayerData.java
+++ b/src/me/Cutiemango/MangoQuest/data/QuestPlayerData.java
@@ -631,15 +631,15 @@ public class QuestPlayerData
 	public String getQuestDisplayFormat(Quest q) {
 		if (canTake(q, false)) {
 			if (hasFinished(q))
-				return I18n.locMsg("QuestGUI.RedoableQuestSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
+				return I18n.locMsg("QuestGUI.RedoableQuestSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
 			else
-				return I18n.locMsg("QuestGUI.NewQuestSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
+				return I18n.locMsg("QuestGUI.NewQuestSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
 		} else {
 			for (QuestObjectProgress op : getProgress(q).getCurrentObjects()) {
 				if (op.getObject() instanceof QuestObjectTalkToNPC && !op.isFinished())
-					return I18n.locMsg("QuestGUI.QuestReturnSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
+					return I18n.locMsg("QuestGUI.QuestReturnSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
 			}
-			return I18n.locMsg("QuestGUI.QuestDoingSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
+			return I18n.locMsg("QuestGUI.QuestDoingSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
 		}
 	}
 

--- a/src/me/Cutiemango/MangoQuest/data/QuestProgress.java
+++ b/src/me/Cutiemango/MangoQuest/data/QuestProgress.java
@@ -81,12 +81,13 @@ public class QuestProgress
 		}
 	}
 
-	public void checkIfNextStage() {
+	public boolean checkIfNextStage() {
 		for (QuestObjectProgress o : objList) {
 			if (!o.isFinished())
-				return;
+				return false;
 		}
 		nextStage();
+		return true;
 	}
 
 	public void nextStage() {

--- a/src/me/Cutiemango/MangoQuest/questobject/objects/QuestObjectConsumeItem.java
+++ b/src/me/Cutiemango/MangoQuest/questobject/objects/QuestObjectConsumeItem.java
@@ -8,6 +8,7 @@ import me.Cutiemango.MangoQuest.book.QuestBookPage;
 import me.Cutiemango.MangoQuest.editor.EditorListenerObject;
 import me.Cutiemango.MangoQuest.questobject.ItemObject;
 import me.Cutiemango.MangoQuest.questobject.interfaces.EditorObject;
+import me.Cutiemango.MangoQuest.book.ItemSafeInteractiveText;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.entity.Player;
@@ -53,7 +54,7 @@ public class QuestObjectConsumeItem extends ItemObject implements EditorObject
 	@Override
 	public void formatEditorPage(QuestBookPage page, int stage, int obj) {
 		page.add(I18n.locMsg("QuestEditor.ConsumeItem"));
-		page.add(new InteractiveText(item));
+		page.add(new ItemSafeInteractiveText(item));
 		page.add(new InteractiveText(I18n.locMsg("QuestEditor.Edit")).clickCommand("/mq e edit object " + stage + " " + obj + " item")).changeLine();
 		super.formatEditorPage(page, stage, obj);
 	}

--- a/src/me/Cutiemango/MangoQuest/questobject/objects/QuestObjectDeliverItem.java
+++ b/src/me/Cutiemango/MangoQuest/questobject/objects/QuestObjectDeliverItem.java
@@ -12,6 +12,7 @@ import me.Cutiemango.MangoQuest.manager.QuestValidater;
 import me.Cutiemango.MangoQuest.questobject.ItemObject;
 import me.Cutiemango.MangoQuest.questobject.interfaces.EditorObject;
 import me.Cutiemango.MangoQuest.questobject.interfaces.NPCObject;
+import me.Cutiemango.MangoQuest.book.ItemSafeInteractiveText;
 import net.citizensnpcs.api.npc.NPC;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.TextComponent;
@@ -73,7 +74,7 @@ public class QuestObjectDeliverItem extends ItemObject implements NPCObject, Edi
 	@Override
 	public void formatEditorPage(QuestBookPage page, int stage, int obj) {
 		page.add(I18n.locMsg("QuestEditor.DeliverItem"));
-		page.add(new InteractiveText(item));
+		page.add(new ItemSafeInteractiveText(item));
 		page.add(new InteractiveText(I18n.locMsg("QuestEditor.Edit")).clickCommand("/mq e edit object " + stage + " " + obj + " item")).changeLine();
 		page.add(I18n.locMsg("QuestEditor.DeliverNPC"));
 		if (npc == null)


### PR DESCRIPTION
### ISSUE
Detailed explanation:
When there is one or more similar items within multiple quests within the same npc,the checkItem(qop,npc) is called multiple times which causes the progress being set to complete when enough items are delivered but at the same time not updating the objective completion because checkFinished is callled only once,
causing the progress display to glitch and showing eg (deliver dead_bush to abc 15/15) but with no strikethrough symbol indicating it to be completed

### CAUSE:
the filter function used in the stream api sets progress while filtering which means other items may match
with the new loop function,it will stop calling multiple checkItem and only call once checkItem when it finds the first match.

### Solution:

- Use for loop instead of the checkItem filter that messes with item progress out of expectation.

- Also forced nextstage/finish check when quest exists in the world in this/other npc for fixing the other problem(finishing all the item deliveries but the questprogress class isnt finished) This can be removed if the problems do not persist.