### PR TITLE
Item Objective Detection Fix + Stage Finish Check + Long NBTTag Book display Crash

### DIFF
--- a/src/me/Cutiemango/MangoQuest/ConfigSettings.java
+++ b/src/me/Cutiemango/MangoQuest/ConfigSettings.java
@@ -13,12 +13,12 @@ public class ConfigSettings
 	// SQL Garbage Collector in ticks
 	public static int SQL_CLEAR_INTERVAL_IN_TICKS = 24000;
 	public static int CONVERSATION_ACTION_INTERVAL_IN_TICKS = 25;
+	public static final int MAX_LENGTH = 600;
 
 	public static boolean POP_LOGIN_MESSAGE = true;
 	public static boolean ENABLE_SCOREBOARD = true;
 	public static boolean USE_PARTICLE_EFFECT = true;
 	public static boolean ENABLE_SKIP = false;
-	public static final int MAX_LENGTH = 800;
 	
 
 	public static boolean USE_WEAK_ITEM_CHECK = false;

--- a/src/me/Cutiemango/MangoQuest/ConfigSettings.java
+++ b/src/me/Cutiemango/MangoQuest/ConfigSettings.java
@@ -18,6 +18,7 @@ public class ConfigSettings
 	public static boolean ENABLE_SCOREBOARD = true;
 	public static boolean USE_PARTICLE_EFFECT = true;
 	public static boolean ENABLE_SKIP = false;
+	public static final int MAX_LENGTH = 800;
 	
 
 	public static boolean USE_WEAK_ITEM_CHECK = false;

--- a/src/me/Cutiemango/MangoQuest/book/InteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/InteractiveText.java
@@ -1,5 +1,8 @@
 package me.Cutiemango.MangoQuest.book;
 
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
 import me.Cutiemango.MangoQuest.data.QuestPlayerData;
 import me.Cutiemango.MangoQuest.manager.QuestChatManager;
 import me.Cutiemango.MangoQuest.model.Quest;
@@ -8,8 +11,6 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
-import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.NotNull;
 
 public class InteractiveText
 {
@@ -23,7 +24,9 @@ public class InteractiveText
 
 	// similar to showItem
 	public InteractiveText(@NotNull ItemStack item) {
+		if(!this.getClass().isAssignableFrom(ItemSafeInteractiveText.class)) {
 		text = TextComponentFactory.convertItemHoverEvent(item, false);
+		}
 	}
 
 	private TextComponent text;

--- a/src/me/Cutiemango/MangoQuest/book/InteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/InteractiveText.java
@@ -1,71 +1,166 @@
 package me.Cutiemango.MangoQuest.book;
 
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+import java.util.logging.Level;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 
+import me.Cutiemango.MangoQuest.ConfigSettings;
 import me.Cutiemango.MangoQuest.data.QuestPlayerData;
 import me.Cutiemango.MangoQuest.manager.QuestChatManager;
 import me.Cutiemango.MangoQuest.model.Quest;
 import net.citizensnpcs.api.npc.NPC;
+import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 
-public class InteractiveText
-{
-	public InteractiveText(TextComponent t) {
+public class ItemSafeInteractiveText extends InteractiveText{
+	private TextComponent text;
+	
+	public ItemSafeInteractiveText(TextComponent t) {
+		super(t);
 		text = t;
+		super.text = t;
 	}
 
-	public InteractiveText(String s) {
+	public ItemSafeInteractiveText(String s) {
 		this(new TextComponent(TextComponent.fromLegacyText(QuestChatManager.translateColor(s))));
+		super.text =this.text;
 	}
 
 	// similar to showItem
-	public InteractiveText(@NotNull ItemStack item) {
-		if(!this.getClass().isAssignableFrom(ItemSafeInteractiveText.class)) {
-		text = TextComponentFactory.convertItemHoverEvent(item, false);
+	public ItemSafeInteractiveText(@NotNull ItemStack item) {
+		super(item);
+		int bytelen = 0;
+		ItemStack itemclone = item.clone();
+		ItemMeta meta = itemclone.getItemMeta();
+		if (meta.hasDisplayName()) {
+			try {
+				bytelen += meta.getDisplayName().getBytes("UTF-8").length;
+			} catch (UnsupportedEncodingException e) {
+				QuestChatManager.logCmd(Level.WARNING, " Cannot get item display name byte length in utf 8");
+				e.printStackTrace();
+			}
 		}
+		if (meta.hasLore()) {
+			List<String> temp = meta.getLore();
+			int index = -1;
+			for (String t : temp) {
+				index++;
+				try {
+					int length = t.getBytes("UTF-8").length;
+					if(bytelen+length > ConfigSettings.MAX_LENGTH) {
+						index--;
+						break;
+					}
+				    bytelen+=length;
+				} catch (UnsupportedEncodingException e) {
+    				QuestChatManager.logCmd(Level.WARNING, " Cannot get item lore byte length in utf 8");
+					e.printStackTrace();
+				}
+			}
+			temp = temp.subList(0, index);
+			temp.add(ChatColor.translateAlternateColorCodes('&', "&2..........................."));
+			meta.setLore(temp);
+			itemclone.setItemMeta(meta);
+		}
+	
+	    text = TextComponentFactory.convertItemHoverEvent(itemclone, false);
+	    super.text = this.text;
+        for(Player p:Bukkit.getOnlinePlayers()) {
+        	p.spigot().sendMessage(text);
+        }
+		//debug
+	   
 	}
 
-	private TextComponent text;
+
 
 	// "/" needed.
-	public InteractiveText clickCommand(String cmd) {
+	public ItemSafeInteractiveText clickCommand(String cmd) {
 		if (!cmd.startsWith("/"))
 			cmd = "/" + cmd;
 		text.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, cmd));
 		return this;
 	}
 
-	public InteractiveText showItem(@NotNull ItemStack item) {
-		text.addExtra(TextComponentFactory.convertItemHoverEvent(item, false));
+	public ItemSafeInteractiveText showItem(@NotNull ItemStack item) {
+		int bytelen = 0;
+		ItemStack itemclone = item.clone();
+		ItemMeta meta = itemclone.getItemMeta();
+		if (meta.hasDisplayName()) {
+			try {
+				bytelen += meta.getDisplayName().getBytes("UTF-8").length;
+			} catch (UnsupportedEncodingException e) {
+				QuestChatManager.logCmd(Level.WARNING, " Cannot get item display name byte length in utf 8");
+				e.printStackTrace();
+			}
+		}
+		if (meta.hasLore()) {
+			List<String> temp = meta.getLore();
+			int index = -1;
+			for (String t : temp) {
+				index++;
+			
+				try {
+					int length = t.getBytes("UTF-8").length;
+					if(bytelen+length > ConfigSettings.MAX_LENGTH) {
+
+						index--;
+						break;
+					}
+				    bytelen+=length;
+				} catch (UnsupportedEncodingException e) {
+    				QuestChatManager.logCmd(Level.WARNING, " Cannot get item lore byte length in utf 8");
+					e.printStackTrace();
+				}
+				
+
+			}
+			temp = temp.subList(0, index);
+			meta.setLore(temp);
+			itemclone.setItemMeta(meta);
+		}
+
+		
+		text = TextComponentFactory.convertItemHoverEvent(itemclone, false);
+		super.text = this.text;
 		return this;
 	}
 
-	public InteractiveText showText(String s) {
-		text.setHoverEvent(
-				new HoverEvent(HoverEvent.Action.SHOW_TEXT, new BaseComponent[] { new TextComponent(QuestChatManager.translateColor(s)) }));
+	public ItemSafeInteractiveText showText(String s) {
+		text.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+				new BaseComponent[] { new TextComponent(QuestChatManager.translateColor(s)) }));
+		super.text = this.text;
 		return this;
 	}
 
-	public InteractiveText showNPCInfo(@NotNull NPC npc) {
+	public ItemSafeInteractiveText showNPCInfo(@NotNull NPC npc) {
 		text.addExtra(TextComponentFactory.convertLocHoverEvent(npc.getName(), npc.getStoredLocation(), false));
+		super.text = this.text;
 		return this;
 	}
 
 	// display: quest's displayName
 	// hover: "click to view"
-	public InteractiveText showQuest(Quest q) {
+	public ItemSafeInteractiveText showQuest(Quest q) {
 		text = TextComponentFactory.convertViewQuest(q);
+		super.text = this.text;
 		return this;
 	}
 
 	// display: quest's displayName
 	// hover: requirement message
-	public InteractiveText showRequirement(QuestPlayerData qd, Quest q) {
+	public ItemSafeInteractiveText showRequirement(QuestPlayerData qd, Quest q) {
 		text = TextComponentFactory.convertRequirement(qd, q);
+		super.text = this.text;
 		return this;
 	}
 

--- a/src/me/Cutiemango/MangoQuest/book/InteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/InteractiveText.java
@@ -25,9 +25,7 @@ public class InteractiveText
 	// similar to showItem
 	public InteractiveText(@NotNull ItemStack item) {
 		
-		if(!this.getClass().isAssignableFrom(ItemSafeInteractiveText.class)) {
 		text = TextComponentFactory.convertItemHoverEvent(item, false);
-		}
 	}
 
 	protected TextComponent text;

--- a/src/me/Cutiemango/MangoQuest/book/InteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/InteractiveText.java
@@ -1,166 +1,72 @@
 package me.Cutiemango.MangoQuest.book;
 
-import java.io.UnsupportedEncodingException;
-import java.util.List;
-import java.util.logging.Level;
-
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 
-import me.Cutiemango.MangoQuest.ConfigSettings;
 import me.Cutiemango.MangoQuest.data.QuestPlayerData;
 import me.Cutiemango.MangoQuest.manager.QuestChatManager;
 import me.Cutiemango.MangoQuest.model.Quest;
 import net.citizensnpcs.api.npc.NPC;
-import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 
-public class ItemSafeInteractiveText extends InteractiveText{
-	private TextComponent text;
-	
-	public ItemSafeInteractiveText(TextComponent t) {
-		super(t);
+public class InteractiveText
+{
+	public InteractiveText(TextComponent t) {
 		text = t;
-		super.text = t;
 	}
 
-	public ItemSafeInteractiveText(String s) {
+	public InteractiveText(String s) {
 		this(new TextComponent(TextComponent.fromLegacyText(QuestChatManager.translateColor(s))));
-		super.text =this.text;
 	}
 
 	// similar to showItem
-	public ItemSafeInteractiveText(@NotNull ItemStack item) {
-		super(item);
-		int bytelen = 0;
-		ItemStack itemclone = item.clone();
-		ItemMeta meta = itemclone.getItemMeta();
-		if (meta.hasDisplayName()) {
-			try {
-				bytelen += meta.getDisplayName().getBytes("UTF-8").length;
-			} catch (UnsupportedEncodingException e) {
-				QuestChatManager.logCmd(Level.WARNING, " Cannot get item display name byte length in utf 8");
-				e.printStackTrace();
-			}
+	public InteractiveText(@NotNull ItemStack item) {
+		
+		if(!this.getClass().isAssignableFrom(ItemSafeInteractiveText.class)) {
+		text = TextComponentFactory.convertItemHoverEvent(item, false);
 		}
-		if (meta.hasLore()) {
-			List<String> temp = meta.getLore();
-			int index = -1;
-			for (String t : temp) {
-				index++;
-				try {
-					int length = t.getBytes("UTF-8").length;
-					if(bytelen+length > ConfigSettings.MAX_LENGTH) {
-						index--;
-						break;
-					}
-				    bytelen+=length;
-				} catch (UnsupportedEncodingException e) {
-    				QuestChatManager.logCmd(Level.WARNING, " Cannot get item lore byte length in utf 8");
-					e.printStackTrace();
-				}
-			}
-			temp = temp.subList(0, index);
-			temp.add(ChatColor.translateAlternateColorCodes('&', "&2..........................."));
-			meta.setLore(temp);
-			itemclone.setItemMeta(meta);
-		}
-	
-	    text = TextComponentFactory.convertItemHoverEvent(itemclone, false);
-	    super.text = this.text;
-        for(Player p:Bukkit.getOnlinePlayers()) {
-        	p.spigot().sendMessage(text);
-        }
-		//debug
-	   
 	}
 
-
+	protected TextComponent text;
 
 	// "/" needed.
-	public ItemSafeInteractiveText clickCommand(String cmd) {
+	public InteractiveText clickCommand(String cmd) {
 		if (!cmd.startsWith("/"))
 			cmd = "/" + cmd;
 		text.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, cmd));
 		return this;
 	}
 
-	public ItemSafeInteractiveText showItem(@NotNull ItemStack item) {
-		int bytelen = 0;
-		ItemStack itemclone = item.clone();
-		ItemMeta meta = itemclone.getItemMeta();
-		if (meta.hasDisplayName()) {
-			try {
-				bytelen += meta.getDisplayName().getBytes("UTF-8").length;
-			} catch (UnsupportedEncodingException e) {
-				QuestChatManager.logCmd(Level.WARNING, " Cannot get item display name byte length in utf 8");
-				e.printStackTrace();
-			}
-		}
-		if (meta.hasLore()) {
-			List<String> temp = meta.getLore();
-			int index = -1;
-			for (String t : temp) {
-				index++;
-			
-				try {
-					int length = t.getBytes("UTF-8").length;
-					if(bytelen+length > ConfigSettings.MAX_LENGTH) {
-
-						index--;
-						break;
-					}
-				    bytelen+=length;
-				} catch (UnsupportedEncodingException e) {
-    				QuestChatManager.logCmd(Level.WARNING, " Cannot get item lore byte length in utf 8");
-					e.printStackTrace();
-				}
-				
-
-			}
-			temp = temp.subList(0, index);
-			meta.setLore(temp);
-			itemclone.setItemMeta(meta);
-		}
-
-		
-		text = TextComponentFactory.convertItemHoverEvent(itemclone, false);
-		super.text = this.text;
+	public InteractiveText showItem(@NotNull ItemStack item) {
+		text.addExtra(TextComponentFactory.convertItemHoverEvent(item, false));
 		return this;
 	}
 
-	public ItemSafeInteractiveText showText(String s) {
-		text.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
-				new BaseComponent[] { new TextComponent(QuestChatManager.translateColor(s)) }));
-		super.text = this.text;
+	public InteractiveText showText(String s) {
+		text.setHoverEvent(
+				new HoverEvent(HoverEvent.Action.SHOW_TEXT, new BaseComponent[] { new TextComponent(QuestChatManager.translateColor(s)) }));
 		return this;
 	}
 
-	public ItemSafeInteractiveText showNPCInfo(@NotNull NPC npc) {
+	public InteractiveText showNPCInfo(@NotNull NPC npc) {
 		text.addExtra(TextComponentFactory.convertLocHoverEvent(npc.getName(), npc.getStoredLocation(), false));
-		super.text = this.text;
 		return this;
 	}
 
 	// display: quest's displayName
 	// hover: "click to view"
-	public ItemSafeInteractiveText showQuest(Quest q) {
+	public InteractiveText showQuest(Quest q) {
 		text = TextComponentFactory.convertViewQuest(q);
-		super.text = this.text;
 		return this;
 	}
 
 	// display: quest's displayName
 	// hover: requirement message
-	public ItemSafeInteractiveText showRequirement(QuestPlayerData qd, Quest q) {
+	public InteractiveText showRequirement(QuestPlayerData qd, Quest q) {
 		text = TextComponentFactory.convertRequirement(qd, q);
-		super.text = this.text;
 		return this;
 	}
 

--- a/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
@@ -101,7 +101,7 @@ public class ItemSafeInteractiveText extends InteractiveText{
 			
 				try {
 					int length = t.getBytes("UTF-8").length;
-					if(bytelen+length > MAX_LENGTH) {
+					if(bytelen+length > ConfigSettings.MAX_LENGTH) {
 
 						index--;
 						break;

--- a/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
@@ -8,6 +8,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 
+import me.Cutiemango.MangoQuest.ConfigSettings;
 import me.Cutiemango.MangoQuest.data.QuestPlayerData;
 import me.Cutiemango.MangoQuest.manager.QuestChatManager;
 import me.Cutiemango.MangoQuest.model.Quest;
@@ -19,7 +20,6 @@ import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 
 public class ItemSafeInteractiveText extends InteractiveText{
-	public static final int MAX_LENGTH =  800;
 	private TextComponent text;
 	
 	public ItemSafeInteractiveText(TextComponent t) {
@@ -53,7 +53,7 @@ public class ItemSafeInteractiveText extends InteractiveText{
 			
 				try {
 					int length = t.getBytes("UTF-8").length;
-					if(bytelen+length > MAX_LENGTH) {
+					if(bytelen+length > ConfigSettings.MAX_LENGTH) {
 						index--;
 						break;
 					}

--- a/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
@@ -1,10 +1,11 @@
 package me.Cutiemango.MangoQuest.book;
 
 import java.io.UnsupportedEncodingException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
@@ -13,13 +14,14 @@ import me.Cutiemango.MangoQuest.data.QuestPlayerData;
 import me.Cutiemango.MangoQuest.manager.QuestChatManager;
 import me.Cutiemango.MangoQuest.model.Quest;
 import net.citizensnpcs.api.npc.NPC;
+import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
 
 public class ItemSafeInteractiveText extends InteractiveText{
-	public static final int MAX_LENGTH = 65535;
+	public static final int MAX_LENGTH =  800;
 	private TextComponent text;
 	
 	public ItemSafeInteractiveText(TextComponent t) {
@@ -35,7 +37,8 @@ public class ItemSafeInteractiveText extends InteractiveText{
 	public ItemSafeInteractiveText(@NotNull ItemStack item) {
 		super(item);
 		int bytelen = 0;
-		ItemMeta meta = item.getItemMeta();
+		ItemStack itemclone = item.clone();
+		ItemMeta meta = itemclone.getItemMeta();
 		if (meta.hasDisplayName()) {
 			try {
 				bytelen += meta.getDisplayName().getBytes("UTF-8").length;
@@ -47,27 +50,32 @@ public class ItemSafeInteractiveText extends InteractiveText{
 		if (meta.hasLore()) {
 			List<String> temp = meta.getLore();
 			int index = -1;
-			List<Integer> indextoremove = new ArrayList<Integer>();
 			for (String t : temp) {
 				index++;
+			
 				try {
 					int length = t.getBytes("UTF-8").length;
 					if(bytelen+length > MAX_LENGTH) {
-						indextoremove.add(length);
+						index--;
 						break;
 					}
 				    bytelen+=length;
 				} catch (UnsupportedEncodingException e) {
-                    indextoremove.add(index);
     				QuestChatManager.logCmd(Level.WARNING, " Cannot get item lore byte length in utf 8");
 					e.printStackTrace();
 				}
-
 			}
+			temp = temp.subList(0, index);
+			temp.add(ChatColor.translateAlternateColorCodes('&', "&2..................."));
 			meta.setLore(temp);
 		}
-		item.setItemMeta(meta);
-		text = TextComponentFactory.convertItemHoverEvent(item, false);
+		itemclone.setItemMeta(meta);
+		text = TextComponentFactory.convertItemHoverEvent(itemclone, false);
+		if(text != null) {
+			for(Player p:Bukkit.getOnlinePlayers()) { 
+				p.spigot().sendMessage(text);
+			}
+		}
 	}
 
 
@@ -82,7 +90,8 @@ public class ItemSafeInteractiveText extends InteractiveText{
 
 	public ItemSafeInteractiveText showItem(@NotNull ItemStack item) {
 		int bytelen = 0;
-		ItemMeta meta = item.getItemMeta();
+		ItemStack itemclone = item.clone();
+		ItemMeta meta = itemclone.getItemMeta();
 		if (meta.hasDisplayName()) {
 			try {
 				bytelen += meta.getDisplayName().getBytes("UTF-8").length;
@@ -94,27 +103,31 @@ public class ItemSafeInteractiveText extends InteractiveText{
 		if (meta.hasLore()) {
 			List<String> temp = meta.getLore();
 			int index = -1;
-			List<Integer> indextoremove = new ArrayList<Integer>();
 			for (String t : temp) {
 				index++;
+			
 				try {
 					int length = t.getBytes("UTF-8").length;
 					if(bytelen+length > MAX_LENGTH) {
-						indextoremove.add(length);
+
+						index--;
 						break;
 					}
 				    bytelen+=length;
 				} catch (UnsupportedEncodingException e) {
-                    indextoremove.add(index);
     				QuestChatManager.logCmd(Level.WARNING, " Cannot get item lore byte length in utf 8");
 					e.printStackTrace();
 				}
+				
 
 			}
+			temp = temp.subList(0, index);
 			meta.setLore(temp);
+			
 		}
-		item.setItemMeta(meta);
-		text.addExtra(TextComponentFactory.convertItemHoverEvent(item, false));
+
+		itemclone.setItemMeta(meta);
+		text = TextComponentFactory.convertItemHoverEvent(itemclone, false);
 		return this;
 	}
 

--- a/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
@@ -71,11 +71,6 @@ public class ItemSafeInteractiveText extends InteractiveText{
 		}
 		itemclone.setItemMeta(meta);
 		text = TextComponentFactory.convertItemHoverEvent(itemclone, false);
-		if(text != null) {
-			for(Player p:Bukkit.getOnlinePlayers()) { 
-				p.spigot().sendMessage(text);
-			}
-		}
 	}
 
 

--- a/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
@@ -4,6 +4,8 @@ import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.logging.Level;
 
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
@@ -25,10 +27,12 @@ public class ItemSafeInteractiveText extends InteractiveText{
 	public ItemSafeInteractiveText(TextComponent t) {
 		super(t);
 		text = t;
+		super.text = t;
 	}
 
 	public ItemSafeInteractiveText(String s) {
 		this(new TextComponent(TextComponent.fromLegacyText(QuestChatManager.translateColor(s))));
+		super.text =this.text;
 	}
 
 	// similar to showItem
@@ -50,7 +54,6 @@ public class ItemSafeInteractiveText extends InteractiveText{
 			int index = -1;
 			for (String t : temp) {
 				index++;
-			
 				try {
 					int length = t.getBytes("UTF-8").length;
 					if(bytelen+length > ConfigSettings.MAX_LENGTH) {
@@ -64,11 +67,18 @@ public class ItemSafeInteractiveText extends InteractiveText{
 				}
 			}
 			temp = temp.subList(0, index);
-			temp.add(ChatColor.translateAlternateColorCodes('&', "&2..................."));
+			temp.add(ChatColor.translateAlternateColorCodes('&', "&2..........................."));
 			meta.setLore(temp);
+			itemclone.setItemMeta(meta);
 		}
-		itemclone.setItemMeta(meta);
-		text = TextComponentFactory.convertItemHoverEvent(itemclone, false);
+	
+	    text = TextComponentFactory.convertItemHoverEvent(itemclone, false);
+	    super.text = this.text;
+        for(Player p:Bukkit.getOnlinePlayers()) {
+        	p.spigot().sendMessage(text);
+        }
+		//debug
+	   
 	}
 
 
@@ -116,22 +126,25 @@ public class ItemSafeInteractiveText extends InteractiveText{
 			}
 			temp = temp.subList(0, index);
 			meta.setLore(temp);
-			
+			itemclone.setItemMeta(meta);
 		}
 
-		itemclone.setItemMeta(meta);
+		
 		text = TextComponentFactory.convertItemHoverEvent(itemclone, false);
+		super.text = this.text;
 		return this;
 	}
 
 	public ItemSafeInteractiveText showText(String s) {
 		text.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
 				new BaseComponent[] { new TextComponent(QuestChatManager.translateColor(s)) }));
+		super.text = this.text;
 		return this;
 	}
 
 	public ItemSafeInteractiveText showNPCInfo(@NotNull NPC npc) {
 		text.addExtra(TextComponentFactory.convertLocHoverEvent(npc.getName(), npc.getStoredLocation(), false));
+		super.text = this.text;
 		return this;
 	}
 
@@ -139,6 +152,7 @@ public class ItemSafeInteractiveText extends InteractiveText{
 	// hover: "click to view"
 	public ItemSafeInteractiveText showQuest(Quest q) {
 		text = TextComponentFactory.convertViewQuest(q);
+		super.text = this.text;
 		return this;
 	}
 
@@ -146,6 +160,7 @@ public class ItemSafeInteractiveText extends InteractiveText{
 	// hover: requirement message
 	public ItemSafeInteractiveText showRequirement(QuestPlayerData qd, Quest q) {
 		text = TextComponentFactory.convertRequirement(qd, q);
+		super.text = this.text;
 		return this;
 	}
 

--- a/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
@@ -4,8 +4,6 @@ import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.logging.Level;
 
-import org.bukkit.Bukkit;
-import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;

--- a/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
@@ -1,0 +1,149 @@
+package me.Cutiemango.MangoQuest.book;
+
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Level;
+
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
+
+import me.Cutiemango.MangoQuest.data.QuestPlayerData;
+import me.Cutiemango.MangoQuest.manager.QuestChatManager;
+import me.Cutiemango.MangoQuest.model.Quest;
+import net.citizensnpcs.api.npc.NPC;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+
+public class ItemSafeInteractiveText extends InteractiveText{
+	public static final int MAX_LENGTH = 65535;
+	private TextComponent text;
+	
+	public ItemSafeInteractiveText(TextComponent t) {
+		super(t);
+		text = t;
+	}
+
+	public ItemSafeInteractiveText(String s) {
+		this(new TextComponent(TextComponent.fromLegacyText(QuestChatManager.translateColor(s))));
+	}
+
+	// similar to showItem
+	public ItemSafeInteractiveText(@NotNull ItemStack item) {
+		super(item);
+		int bytelen = 0;
+		ItemMeta meta = item.getItemMeta();
+		if (meta.hasDisplayName()) {
+			try {
+				bytelen += meta.getDisplayName().getBytes("UTF-8").length;
+			} catch (UnsupportedEncodingException e) {
+				QuestChatManager.logCmd(Level.WARNING, " Cannot get item display name byte length in utf 8");
+				e.printStackTrace();
+			}
+		}
+		if (meta.hasLore()) {
+			List<String> temp = meta.getLore();
+			int index = -1;
+			List<Integer> indextoremove = new ArrayList<Integer>();
+			for (String t : temp) {
+				index++;
+				try {
+					int length = t.getBytes("UTF-8").length;
+					if(bytelen+length > MAX_LENGTH) {
+						indextoremove.add(length);
+						break;
+					}
+				    bytelen+=length;
+				} catch (UnsupportedEncodingException e) {
+                    indextoremove.add(index);
+    				QuestChatManager.logCmd(Level.WARNING, " Cannot get item lore byte length in utf 8");
+					e.printStackTrace();
+				}
+
+			}
+			meta.setLore(temp);
+		}
+		item.setItemMeta(meta);
+		text = TextComponentFactory.convertItemHoverEvent(item, false);
+	}
+
+
+
+	// "/" needed.
+	public ItemSafeInteractiveText clickCommand(String cmd) {
+		if (!cmd.startsWith("/"))
+			cmd = "/" + cmd;
+		text.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, cmd));
+		return this;
+	}
+
+	public ItemSafeInteractiveText showItem(@NotNull ItemStack item) {
+		int bytelen = 0;
+		ItemMeta meta = item.getItemMeta();
+		if (meta.hasDisplayName()) {
+			try {
+				bytelen += meta.getDisplayName().getBytes("UTF-8").length;
+			} catch (UnsupportedEncodingException e) {
+				QuestChatManager.logCmd(Level.WARNING, " Cannot get item display name byte length in utf 8");
+				e.printStackTrace();
+			}
+		}
+		if (meta.hasLore()) {
+			List<String> temp = meta.getLore();
+			int index = -1;
+			List<Integer> indextoremove = new ArrayList<Integer>();
+			for (String t : temp) {
+				index++;
+				try {
+					int length = t.getBytes("UTF-8").length;
+					if(bytelen+length > MAX_LENGTH) {
+						indextoremove.add(length);
+						break;
+					}
+				    bytelen+=length;
+				} catch (UnsupportedEncodingException e) {
+                    indextoremove.add(index);
+    				QuestChatManager.logCmd(Level.WARNING, " Cannot get item lore byte length in utf 8");
+					e.printStackTrace();
+				}
+
+			}
+			meta.setLore(temp);
+		}
+		item.setItemMeta(meta);
+		text.addExtra(TextComponentFactory.convertItemHoverEvent(item, false));
+		return this;
+	}
+
+	public ItemSafeInteractiveText showText(String s) {
+		text.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+				new BaseComponent[] { new TextComponent(QuestChatManager.translateColor(s)) }));
+		return this;
+	}
+
+	public ItemSafeInteractiveText showNPCInfo(@NotNull NPC npc) {
+		text.addExtra(TextComponentFactory.convertLocHoverEvent(npc.getName(), npc.getStoredLocation(), false));
+		return this;
+	}
+
+	// display: quest's displayName
+	// hover: "click to view"
+	public ItemSafeInteractiveText showQuest(Quest q) {
+		text = TextComponentFactory.convertViewQuest(q);
+		return this;
+	}
+
+	// display: quest's displayName
+	// hover: requirement message
+	public ItemSafeInteractiveText showRequirement(QuestPlayerData qd, Quest q) {
+		text = TextComponentFactory.convertRequirement(qd, q);
+		return this;
+	}
+
+	public TextComponent get() {
+		return text;
+	}
+}

--- a/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
@@ -74,9 +74,6 @@ public class ItemSafeInteractiveText extends InteractiveText{
 	
 	    text = TextComponentFactory.convertItemHoverEvent(itemclone, false);
 	    super.text = this.text;
-        for(Player p:Bukkit.getOnlinePlayers()) {
-        	p.spigot().sendMessage(text);
-        }
 		//debug
 	   
 	}

--- a/src/me/Cutiemango/MangoQuest/book/QuestBookPage.java
+++ b/src/me/Cutiemango/MangoQuest/book/QuestBookPage.java
@@ -1,14 +1,14 @@
 package me.Cutiemango.MangoQuest.book;
 
+import java.util.HashMap;
+
 import me.Cutiemango.MangoQuest.Pair;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.TextComponent;
 
-import java.util.HashMap;
-
 public class QuestBookPage
 {
-	private static final double MAXIMUM_CHAR_PER_LINE = 19D;
+	private static final double MAXIMUM_CHAR_PER_LINE = 30D;
 	private static final double MAXIMUM_LINE_PER_PAGE = 14D;
 
 	public static HashMap<Character.UnicodeBlock, Pair<Double, Double>> CHARACTER_SIZEMAP = new HashMap<>();
@@ -129,6 +129,7 @@ public class QuestBookPage
 	}
 
 	public QuestBookPage add(InteractiveText it) {
+		
 		add(it.get());
 		return this;
 	}

--- a/src/me/Cutiemango/MangoQuest/data/QuestPlayerData.java
+++ b/src/me/Cutiemango/MangoQuest/data/QuestPlayerData.java
@@ -469,10 +469,16 @@ public class QuestPlayerData
 
 	public boolean deliverItem(NPC npc) {
 		AtomicReference<Pair<QuestProgress, QuestObjectProgress>> any = new AtomicReference<>();
-		currentQuests.stream().filter(qp -> checkPlayerInWorld(qp.getQuest())).forEach(qp -> {
-			Optional<QuestObjectProgress> obj = qp.getCurrentObjects().stream().filter(qop -> checkItem(qop, npc)).findFirst();
-			obj.ifPresent(qop -> any.set(new Pair<>(qp, qop)));
-		});
+		for(QuestProgress qp:currentQuests) {
+			if(checkPlayerInWorld(qp.getQuest())) {
+				for(QuestObjectProgress qop:qp.getCurrentObjects()) {
+					if(checkItem(qop,npc)) {
+						any.set(new Pair<>(qp,qop));
+						break;
+					}
+				}
+			}
+		}
 		if (any.get() != null) {
 			Pair<QuestProgress, QuestObjectProgress> pair = any.get();
 			checkFinished(pair.getKey(), pair.getValue());
@@ -625,15 +631,15 @@ public class QuestPlayerData
 	public String getQuestDisplayFormat(Quest q) {
 		if (canTake(q, false)) {
 			if (hasFinished(q))
-				return I18n.locMsg("QuestGUI.RedoableQuestSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
+				return I18n.locMsg("QuestGUI.RedoableQuestSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
 			else
-				return I18n.locMsg("QuestGUI.NewQuestSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
+				return I18n.locMsg("QuestGUI.NewQuestSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
 		} else {
 			for (QuestObjectProgress op : getProgress(q).getCurrentObjects()) {
 				if (op.getObject() instanceof QuestObjectTalkToNPC && !op.isFinished())
-					return I18n.locMsg("QuestGUI.QuestReturnSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
+					return I18n.locMsg("QuestGUI.QuestReturnSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
 			}
-			return I18n.locMsg("QuestGUI.QuestDoingSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
+			return I18n.locMsg("QuestGUI.QuestDoingSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
 		}
 	}
 

--- a/src/me/Cutiemango/MangoQuest/data/QuestPlayerData.java
+++ b/src/me/Cutiemango/MangoQuest/data/QuestPlayerData.java
@@ -471,6 +471,9 @@ public class QuestPlayerData
 		AtomicReference<Pair<QuestProgress, QuestObjectProgress>> any = new AtomicReference<>();
 		for(QuestProgress qp:currentQuests) {
 			if(checkPlayerInWorld(qp.getQuest())) {
+				if(qp.checkIfNextStage()){
+				  continue;
+				}
 				for(QuestObjectProgress qop:qp.getCurrentObjects()) {
 					if(checkItem(qop,npc)) {
 						any.set(new Pair<>(qp,qop));

--- a/src/me/Cutiemango/MangoQuest/data/QuestPlayerData.java
+++ b/src/me/Cutiemango/MangoQuest/data/QuestPlayerData.java
@@ -631,15 +631,15 @@ public class QuestPlayerData
 	public String getQuestDisplayFormat(Quest q) {
 		if (canTake(q, false)) {
 			if (hasFinished(q))
-				return I18n.locMsg("QuestGUI.RedoableQuestSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
+				return I18n.locMsg("QuestGUI.RedoableQuestSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
 			else
-				return I18n.locMsg("QuestGUI.NewQuestSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
+				return I18n.locMsg("QuestGUI.NewQuestSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
 		} else {
 			for (QuestObjectProgress op : getProgress(q).getCurrentObjects()) {
 				if (op.getObject() instanceof QuestObjectTalkToNPC && !op.isFinished())
-					return I18n.locMsg("QuestGUI.QuestReturnSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
+					return I18n.locMsg("QuestGUI.QuestReturnSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
 			}
-			return I18n.locMsg("QuestGUI.QuestDoingSymbol").replaceAll("禮0", "禮f") + ChatColor.BOLD + q.getQuestName();
+			return I18n.locMsg("QuestGUI.QuestDoingSymbol").replaceAll("§0", "§f") + ChatColor.BOLD + q.getQuestName();
 		}
 	}
 

--- a/src/me/Cutiemango/MangoQuest/data/QuestProgress.java
+++ b/src/me/Cutiemango/MangoQuest/data/QuestProgress.java
@@ -81,12 +81,13 @@ public class QuestProgress
 		}
 	}
 
-	public void checkIfNextStage() {
+	public boolean checkIfNextStage() {
 		for (QuestObjectProgress o : objList) {
 			if (!o.isFinished())
-				return;
+				return false;
 		}
 		nextStage();
+		return true;
 	}
 
 	public void nextStage() {

--- a/src/me/Cutiemango/MangoQuest/manager/QuestBookGUIManager.java
+++ b/src/me/Cutiemango/MangoQuest/manager/QuestBookGUIManager.java
@@ -89,13 +89,13 @@ public class QuestBookGUIManager
 					book.add("- ");
 					List<ItemStack> items = choice.getItems();
 					for (int j = 0; j < items.size(); j++)
-						book.add(new ItemSafeInteractiveText(items.get(j))).add(j == items.size() - 1 ? "" : ", ");
+						book.add(new ItemSafeInteractiveText(items.get(j)).get()).add(j == items.size() - 1 ? "" : ", ");
 					book.changeLine();
 				}
 			} else {
 				for (ItemStack is : qp.getQuest().getQuestReward().getDefaultChoice().getItems()) {
 					if (is != null) {
-						book.add(new ItemSafeInteractiveText(is));
+						book.add(new ItemSafeInteractiveText(is).get());
 						book.add(" ");
 						book.add(I18n.locMsg("QuestReward.RewardAmount", Integer.toString(is.getAmount()))).changeLine();
 					}

--- a/src/me/Cutiemango/MangoQuest/manager/QuestBookGUIManager.java
+++ b/src/me/Cutiemango/MangoQuest/manager/QuestBookGUIManager.java
@@ -1,11 +1,18 @@
 package me.Cutiemango.MangoQuest.manager;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
 import me.Cutiemango.MangoQuest.I18n;
 import me.Cutiemango.MangoQuest.Main;
 import me.Cutiemango.MangoQuest.QuestStorage;
 import me.Cutiemango.MangoQuest.QuestUtil;
 import me.Cutiemango.MangoQuest.book.FlexibleBook;
 import me.Cutiemango.MangoQuest.book.InteractiveText;
+import me.Cutiemango.MangoQuest.book.ItemSafeInteractiveText;
 import me.Cutiemango.MangoQuest.book.QuestBookPage;
 import me.Cutiemango.MangoQuest.conversation.FriendConversation;
 import me.Cutiemango.MangoQuest.conversation.QuestChoice.Choice;
@@ -21,11 +28,6 @@ import me.Cutiemango.MangoQuest.questobject.NumerableObject;
 import me.Cutiemango.MangoQuest.questobject.SimpleQuestObject;
 import net.citizensnpcs.api.npc.NPC;
 import net.md_5.bungee.api.chat.TextComponent;
-import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class QuestBookGUIManager
 {
@@ -87,13 +89,13 @@ public class QuestBookGUIManager
 					book.add("- ");
 					List<ItemStack> items = choice.getItems();
 					for (int j = 0; j < items.size(); j++)
-						book.add(new InteractiveText(items.get(j))).add(j == items.size() - 1 ? "" : ", ");
+						book.add(new ItemSafeInteractiveText(items.get(j))).add(j == items.size() - 1 ? "" : ", ");
 					book.changeLine();
 				}
 			} else {
 				for (ItemStack is : qp.getQuest().getQuestReward().getDefaultChoice().getItems()) {
 					if (is != null) {
-						book.add(new InteractiveText(is));
+						book.add(new ItemSafeInteractiveText(is));
 						book.add(" ");
 						book.add(I18n.locMsg("QuestReward.RewardAmount", Integer.toString(is.getAmount()))).changeLine();
 					}

--- a/src/me/Cutiemango/MangoQuest/questobject/SimpleQuestObject.java
+++ b/src/me/Cutiemango/MangoQuest/questobject/SimpleQuestObject.java
@@ -1,8 +1,16 @@
 package me.Cutiemango.MangoQuest.questobject;
 
+import java.util.HashMap;
+
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.ItemStack;
+
 import me.Cutiemango.MangoQuest.I18n;
 import me.Cutiemango.MangoQuest.QuestIO;
 import me.Cutiemango.MangoQuest.QuestUtil;
+import me.Cutiemango.MangoQuest.book.ItemSafeInteractiveText;
 import me.Cutiemango.MangoQuest.book.TextComponentFactory;
 import me.Cutiemango.MangoQuest.conversation.ConversationManager;
 import me.Cutiemango.MangoQuest.conversation.QuestConversation;
@@ -10,12 +18,6 @@ import me.Cutiemango.MangoQuest.manager.QuestChatManager;
 import net.citizensnpcs.api.npc.NPC;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.TextComponent;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.entity.EntityType;
-import org.bukkit.inventory.ItemStack;
-
-import java.util.HashMap;
 
 public abstract class SimpleQuestObject
 {
@@ -59,9 +61,9 @@ public abstract class SimpleQuestObject
 			} else
 				left = "";
 
-			if (args[i] instanceof ItemStack)
-				text.addExtra(TextComponentFactory.convertItemHoverEvent((ItemStack) args[i], isFinished));
-			else if (args[i] instanceof Integer)
+			if (args[i] instanceof ItemStack) {
+			   new ItemSafeInteractiveText((ItemStack)args[i]).get();
+			}else if (args[i] instanceof Integer)
 				text.addExtra(color + args[i]);
 			else if (args[i] instanceof NPC) {
 				NPC npc = (NPC) args[i];

--- a/src/me/Cutiemango/MangoQuest/questobject/SimpleQuestObject.java
+++ b/src/me/Cutiemango/MangoQuest/questobject/SimpleQuestObject.java
@@ -2,9 +2,11 @@ package me.Cutiemango.MangoQuest.questobject;
 
 import java.util.HashMap;
 
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 import me.Cutiemango.MangoQuest.I18n;
@@ -62,7 +64,7 @@ public abstract class SimpleQuestObject
 				left = "";
 
 			if (args[i] instanceof ItemStack) {
-			   new ItemSafeInteractiveText((ItemStack)args[i]).get();
+			   text.addExtra(new ItemSafeInteractiveText((ItemStack)args[i]).get());
 			}else if (args[i] instanceof Integer)
 				text.addExtra(color + args[i]);
 			else if (args[i] instanceof NPC) {
@@ -93,6 +95,9 @@ public abstract class SimpleQuestObject
 		if (block != null)
 			text.addExtra(color + QuestUtil.translate(block));
 		text.addExtra(color + left);
+		for(Player p:Bukkit.getOnlinePlayers()) {
+			p.spigot().sendMessage(text);
+		}
 		return text;
 	}
 

--- a/src/me/Cutiemango/MangoQuest/questobject/objects/QuestObjectConsumeItem.java
+++ b/src/me/Cutiemango/MangoQuest/questobject/objects/QuestObjectConsumeItem.java
@@ -8,6 +8,7 @@ import me.Cutiemango.MangoQuest.book.QuestBookPage;
 import me.Cutiemango.MangoQuest.editor.EditorListenerObject;
 import me.Cutiemango.MangoQuest.questobject.ItemObject;
 import me.Cutiemango.MangoQuest.questobject.interfaces.EditorObject;
+import me.Cutiemango.MangoQuest.book.ItemSafeInteractiveText;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.entity.Player;
@@ -53,7 +54,7 @@ public class QuestObjectConsumeItem extends ItemObject implements EditorObject
 	@Override
 	public void formatEditorPage(QuestBookPage page, int stage, int obj) {
 		page.add(I18n.locMsg("QuestEditor.ConsumeItem"));
-		page.add(new InteractiveText(item));
+		page.add(new ItemSafeInteractiveText(item));
 		page.add(new InteractiveText(I18n.locMsg("QuestEditor.Edit")).clickCommand("/mq e edit object " + stage + " " + obj + " item")).changeLine();
 		super.formatEditorPage(page, stage, obj);
 	}

--- a/src/me/Cutiemango/MangoQuest/questobject/objects/QuestObjectDeliverItem.java
+++ b/src/me/Cutiemango/MangoQuest/questobject/objects/QuestObjectDeliverItem.java
@@ -12,6 +12,7 @@ import me.Cutiemango.MangoQuest.manager.QuestValidater;
 import me.Cutiemango.MangoQuest.questobject.ItemObject;
 import me.Cutiemango.MangoQuest.questobject.interfaces.EditorObject;
 import me.Cutiemango.MangoQuest.questobject.interfaces.NPCObject;
+import me.Cutiemango.MangoQuest.book.ItemSafeInteractiveText;
 import net.citizensnpcs.api.npc.NPC;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.TextComponent;
@@ -73,7 +74,7 @@ public class QuestObjectDeliverItem extends ItemObject implements NPCObject, Edi
 	@Override
 	public void formatEditorPage(QuestBookPage page, int stage, int obj) {
 		page.add(I18n.locMsg("QuestEditor.DeliverItem"));
-		page.add(new InteractiveText(item));
+		page.add(new ItemSafeInteractiveText(item));
 		page.add(new InteractiveText(I18n.locMsg("QuestEditor.Edit")).clickCommand("/mq e edit object " + stage + " " + obj + " item")).changeLine();
 		page.add(I18n.locMsg("QuestEditor.DeliverNPC"));
 		if (npc == null)


### PR DESCRIPTION
**WORKING 100% MORE LEGIT THAN MY EXISTENCE**
**This update is thoroughly tested and it worked exceptionally well(Tested in 1.16.5 by himehina and 1.17 in foreign server).If there are still any bugs,I will fix it swiftly and asap.You have my words.**

**OVERVIEW**

- Modified QuestPlayerData's checkifnextstage and replaced stream with regular loop with breaks in deliverItem
- Added checkifnextstage check before CheckItem method in the loop
- Modified InteractiveText.java to make the constructor only work if it has no subclass and also made textcomponent protected
- Added ItemSafeInteractiveText which omit lore length (cloned itemstack with length check)
- Modified ConfigSettings (added MAX_LENGTH OF UTF 8 CHARSET) for ItemSafeInteractiveText character threshold
- Modified SImpleQuestObject totextcomponent method
- .........various functions for item formatting(lol my memory is not that good tbh

### ISSUES ADDRESSED IN THIS PR:

- When there are similar items objectives with same target npc and within the same quest or in two separate quests,both item objectives will receive progress,causing that only one of the objective undergo finish check leaving another with full progress but without finish update.
- There is a chance where the item objectives are completed,the objective's finish status will not be updated.
- When using long nbt tag(lower than or higher than 65535 limit),the hover message in the book will not be able to handle such a large nbttag,causing error.(Note that the 65535 limit isnt very reasonable considering that each chinese character take 2 bytes at a time.and its likely that a hundred chinese characters can already crash it so it has to be fixed).

### SOLUTION:

- The first issue is due to the stream api that calls the checkitem method for filtering,implying that each item will undergo checkitem(progress update) while only one item will be fetched from the stream api for finish checking,causing progress confusing(No strikethrough for other similar item) 
   It is addressed by using a regular loop instead which breaks on found,preventing the next item receiving progress update
   (_**ie only deal with one item at one time**_)

- Modified CheckIfNextStage to returns boolean in the item loop for finish checking which addresses the second problem
- The third issue can be addressed by making a new class ItemSafeInteractiveText.java and modifying simplequestobject and various totextcomponent methods to reduce the item lore length in order to prevent crashing.The reduced lore will be represented by ellipsis instead.(  _**IT WILL NOT MESS WITH THE ORIGINAL ITEMSTACK AND IT IS A CLONED ITEMSTACK**_

### ADDITIONAL UPDATE:

- Extended Character length in questbookpage class for better page formatting.(Reported bug and should be addressed imo)

**Allow me to restate again that this is thoroughly checked and rare should errors emerge.Should you find any errors,feel free to contact me immediately for further testing and modification**
