### PR TITLE
Feat:Larger NBT ItemStack display

### DIFF
--- a/src/me/Cutiemango/MangoQuest/ConfigSettings.java
+++ b/src/me/Cutiemango/MangoQuest/ConfigSettings.java
@@ -13,6 +13,7 @@ public class ConfigSettings
 	// SQL Garbage Collector in ticks
 	public static int SQL_CLEAR_INTERVAL_IN_TICKS = 24000;
 	public static int CONVERSATION_ACTION_INTERVAL_IN_TICKS = 25;
+	public static final int MAX_LENGTH = 600;
 
 	public static boolean POP_LOGIN_MESSAGE = true;
 	public static boolean ENABLE_SCOREBOARD = true;

--- a/src/me/Cutiemango/MangoQuest/book/InteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/InteractiveText.java
@@ -1,5 +1,8 @@
 package me.Cutiemango.MangoQuest.book;
 
+import org.bukkit.inventory.ItemStack;
+import org.jetbrains.annotations.NotNull;
+
 import me.Cutiemango.MangoQuest.data.QuestPlayerData;
 import me.Cutiemango.MangoQuest.manager.QuestChatManager;
 import me.Cutiemango.MangoQuest.model.Quest;
@@ -8,8 +11,6 @@ import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ClickEvent;
 import net.md_5.bungee.api.chat.HoverEvent;
 import net.md_5.bungee.api.chat.TextComponent;
-import org.bukkit.inventory.ItemStack;
-import org.jetbrains.annotations.NotNull;
 
 public class InteractiveText
 {
@@ -23,10 +24,13 @@ public class InteractiveText
 
 	// similar to showItem
 	public InteractiveText(@NotNull ItemStack item) {
+		
+		//if(!this.getClass().isAssignableFrom(ItemSafeInteractiveText.class)) {
 		text = TextComponentFactory.convertItemHoverEvent(item, false);
+		//}
 	}
 
-	private TextComponent text;
+	protected TextComponent text;
 
 	// "/" needed.
 	public InteractiveText clickCommand(String cmd) {

--- a/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
+++ b/src/me/Cutiemango/MangoQuest/book/ItemSafeInteractiveText.java
@@ -1,0 +1,165 @@
+package me.Cutiemango.MangoQuest.book;
+
+import java.io.UnsupportedEncodingException;
+import java.util.List;
+import java.util.logging.Level;
+
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
+
+import me.Cutiemango.MangoQuest.ConfigSettings;
+import me.Cutiemango.MangoQuest.data.QuestPlayerData;
+import me.Cutiemango.MangoQuest.manager.QuestChatManager;
+import me.Cutiemango.MangoQuest.model.Quest;
+import net.citizensnpcs.api.npc.NPC;
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+
+public class ItemSafeInteractiveText extends InteractiveText{
+	private TextComponent text;
+	
+	public ItemSafeInteractiveText(TextComponent t) {
+		super(t);
+		text = t;
+		super.text = t;
+	}
+
+	public ItemSafeInteractiveText(String s) {
+		this(new TextComponent(TextComponent.fromLegacyText(QuestChatManager.translateColor(s))));
+		super.text =this.text;
+	}
+
+	// similar to showItem
+	public ItemSafeInteractiveText(@NotNull ItemStack item) {
+		super(item);
+		int bytelen = 0;
+		ItemStack itemclone = item.clone();
+		ItemMeta meta = itemclone.getItemMeta();
+		if (meta.hasDisplayName()) {
+			try {
+				bytelen += meta.getDisplayName().getBytes("UTF-8").length;
+			} catch (UnsupportedEncodingException e) {
+				QuestChatManager.logCmd(Level.WARNING, " Cannot get item display name byte length in utf 8");
+				e.printStackTrace();
+			}
+		}
+		if (meta.hasLore()) {
+			List<String> temp = meta.getLore();
+			int index = -1;
+			for (String t : temp) {
+				index++;
+				try {
+					int length = t.getBytes("UTF-8").length;
+					if(bytelen+length > ConfigSettings.MAX_LENGTH) {
+						index--;
+						break;
+					}
+				    bytelen+=length;
+				} catch (UnsupportedEncodingException e) {
+    				QuestChatManager.logCmd(Level.WARNING, " Cannot get item lore byte length in utf 8");
+					e.printStackTrace();
+				}
+			}
+			temp = temp.subList(0, index);
+			temp.add(ChatColor.translateAlternateColorCodes('&', "&2..........................."));
+			meta.setLore(temp);
+			itemclone.setItemMeta(meta);
+		}
+	
+	    text = TextComponentFactory.convertItemHoverEvent(itemclone, false);
+	    super.text = this.text;
+		//debug
+	   
+	}
+
+
+
+	// "/" needed.
+	public ItemSafeInteractiveText clickCommand(String cmd) {
+		if (!cmd.startsWith("/"))
+			cmd = "/" + cmd;
+		text.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, cmd));
+		return this;
+	}
+
+	public ItemSafeInteractiveText showItem(@NotNull ItemStack item) {
+		int bytelen = 0;
+		ItemStack itemclone = item.clone();
+		ItemMeta meta = itemclone.getItemMeta();
+		if (meta.hasDisplayName()) {
+			try {
+				bytelen += meta.getDisplayName().getBytes("UTF-8").length;
+			} catch (UnsupportedEncodingException e) {
+				QuestChatManager.logCmd(Level.WARNING, " Cannot get item display name byte length in utf 8");
+				e.printStackTrace();
+			}
+		}
+		if (meta.hasLore()) {
+			List<String> temp = meta.getLore();
+			int index = -1;
+			for (String t : temp) {
+				index++;
+			
+				try {
+					int length = t.getBytes("UTF-8").length;
+					if(bytelen+length > ConfigSettings.MAX_LENGTH) {
+
+						index--;
+						break;
+					}
+				    bytelen+=length;
+				} catch (UnsupportedEncodingException e) {
+    				QuestChatManager.logCmd(Level.WARNING, " Cannot get item lore byte length in utf 8");
+					e.printStackTrace();
+				}
+				
+
+			}
+			temp = temp.subList(0, index);
+			meta.setLore(temp);
+			itemclone.setItemMeta(meta);
+		}
+
+		
+		text = TextComponentFactory.convertItemHoverEvent(itemclone, false);
+		super.text = this.text;
+		return this;
+	}
+
+	public ItemSafeInteractiveText showText(String s) {
+		text.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT,
+				new BaseComponent[] { new TextComponent(QuestChatManager.translateColor(s)) }));
+		super.text = this.text;
+		return this;
+	}
+
+	public ItemSafeInteractiveText showNPCInfo(@NotNull NPC npc) {
+		text.addExtra(TextComponentFactory.convertLocHoverEvent(npc.getName(), npc.getStoredLocation(), false));
+		super.text = this.text;
+		return this;
+	}
+
+	// display: quest's displayName
+	// hover: "click to view"
+	public ItemSafeInteractiveText showQuest(Quest q) {
+		text = TextComponentFactory.convertViewQuest(q);
+		super.text = this.text;
+		return this;
+	}
+
+	// display: quest's displayName
+	// hover: requirement message
+	public ItemSafeInteractiveText showRequirement(QuestPlayerData qd, Quest q) {
+		text = TextComponentFactory.convertRequirement(qd, q);
+		super.text = this.text;
+		return this;
+	}
+
+	public TextComponent get() {
+		return text;
+	}
+}

--- a/src/me/Cutiemango/MangoQuest/questobject/SimpleQuestObject.java
+++ b/src/me/Cutiemango/MangoQuest/questobject/SimpleQuestObject.java
@@ -1,8 +1,18 @@
 package me.Cutiemango.MangoQuest.questobject;
 
+import java.util.HashMap;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
 import me.Cutiemango.MangoQuest.I18n;
 import me.Cutiemango.MangoQuest.QuestIO;
 import me.Cutiemango.MangoQuest.QuestUtil;
+import me.Cutiemango.MangoQuest.book.ItemSafeInteractiveText;
 import me.Cutiemango.MangoQuest.book.TextComponentFactory;
 import me.Cutiemango.MangoQuest.conversation.ConversationManager;
 import me.Cutiemango.MangoQuest.conversation.QuestConversation;
@@ -10,12 +20,6 @@ import me.Cutiemango.MangoQuest.manager.QuestChatManager;
 import net.citizensnpcs.api.npc.NPC;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.TextComponent;
-import org.bukkit.Location;
-import org.bukkit.Material;
-import org.bukkit.entity.EntityType;
-import org.bukkit.inventory.ItemStack;
-
-import java.util.HashMap;
 
 public abstract class SimpleQuestObject
 {
@@ -59,9 +63,9 @@ public abstract class SimpleQuestObject
 			} else
 				left = "";
 
-			if (args[i] instanceof ItemStack)
-				text.addExtra(TextComponentFactory.convertItemHoverEvent((ItemStack) args[i], isFinished));
-			else if (args[i] instanceof Integer)
+			if (args[i] instanceof ItemStack) {
+			   text.addExtra(new ItemSafeInteractiveText((ItemStack)args[i]).get());
+			}else if (args[i] instanceof Integer)
 				text.addExtra(color + args[i]);
 			else if (args[i] instanceof NPC) {
 				NPC npc = (NPC) args[i];
@@ -91,6 +95,9 @@ public abstract class SimpleQuestObject
 		if (block != null)
 			text.addExtra(color + QuestUtil.translate(block));
 		text.addExtra(color + left);
+		///for(Player p:Bukkit.getOnlinePlayers()) {
+		//	p.spigot().sendMessage(text);
+		//}
 		return text;
 	}
 

--- a/src/me/Cutiemango/MangoQuest/questobject/objects/QuestObjectConsumeItem.java
+++ b/src/me/Cutiemango/MangoQuest/questobject/objects/QuestObjectConsumeItem.java
@@ -1,17 +1,19 @@
 package me.Cutiemango.MangoQuest.questobject.objects;
 
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
 import me.Cutiemango.MangoQuest.I18n;
 import me.Cutiemango.MangoQuest.QuestIO;
 import me.Cutiemango.MangoQuest.QuestUtil;
 import me.Cutiemango.MangoQuest.book.InteractiveText;
+import me.Cutiemango.MangoQuest.book.ItemSafeInteractiveText;
 import me.Cutiemango.MangoQuest.book.QuestBookPage;
 import me.Cutiemango.MangoQuest.editor.EditorListenerObject;
 import me.Cutiemango.MangoQuest.questobject.ItemObject;
 import me.Cutiemango.MangoQuest.questobject.interfaces.EditorObject;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.TextComponent;
-import org.bukkit.entity.Player;
-import org.bukkit.inventory.ItemStack;
 
 public class QuestObjectConsumeItem extends ItemObject implements EditorObject
 {
@@ -53,7 +55,7 @@ public class QuestObjectConsumeItem extends ItemObject implements EditorObject
 	@Override
 	public void formatEditorPage(QuestBookPage page, int stage, int obj) {
 		page.add(I18n.locMsg("QuestEditor.ConsumeItem"));
-		page.add(new InteractiveText(item));
+		page.add(new ItemSafeInteractiveText(item));
 		page.add(new InteractiveText(I18n.locMsg("QuestEditor.Edit")).clickCommand("/mq e edit object " + stage + " " + obj + " item")).changeLine();
 		super.formatEditorPage(page, stage, obj);
 	}

--- a/src/me/Cutiemango/MangoQuest/questobject/objects/QuestObjectDeliverItem.java
+++ b/src/me/Cutiemango/MangoQuest/questobject/objects/QuestObjectDeliverItem.java
@@ -12,6 +12,7 @@ import me.Cutiemango.MangoQuest.manager.QuestValidater;
 import me.Cutiemango.MangoQuest.questobject.ItemObject;
 import me.Cutiemango.MangoQuest.questobject.interfaces.EditorObject;
 import me.Cutiemango.MangoQuest.questobject.interfaces.NPCObject;
+import me.Cutiemango.MangoQuest.book.ItemSafeInteractiveText;
 import net.citizensnpcs.api.npc.NPC;
 import net.md_5.bungee.api.ChatColor;
 import net.md_5.bungee.api.chat.TextComponent;
@@ -73,7 +74,7 @@ public class QuestObjectDeliverItem extends ItemObject implements NPCObject, Edi
 	@Override
 	public void formatEditorPage(QuestBookPage page, int stage, int obj) {
 		page.add(I18n.locMsg("QuestEditor.DeliverItem"));
-		page.add(new InteractiveText(item));
+		page.add(new ItemSafeInteractiveText(item));
 		page.add(new InteractiveText(I18n.locMsg("QuestEditor.Edit")).clickCommand("/mq e edit object " + stage + " " + obj + " item")).changeLine();
 		page.add(I18n.locMsg("QuestEditor.DeliverNPC"));
 		if (npc == null)


### PR DESCRIPTION
### ISSUE
When showing items with large itemstack with super large nbt tag(possibly exceed 65535 byte length),it will kick players out with encoded String too large exception in netty.

### SOURCE OF THE PROBLEM
Upon further investigation,I found that the item crashes when the book is trying to format the item.

### WHY FIX THIS PROBLEM?
65535 byte length...seems unreasonably large?but actually,just with a bit of color formatting and a bit more than a hundred chinese characters,can already crash it,considering that nbttag uses large amount of tags for colour and also chinese character occupies two bytes each.The 65535 byte length seems unreasonable.Therefore,it can be potentially a cure for many mangoquest users to be able to load items with much larger nbt tags.

### SOLUTION
Added class ItemSafeInteractiveText.java for better formatting.Also fixed InteractiveText.java,and various quest object classes and config settings to complement this change.
(It is basically a change to omit item lores that exceeds the max_length range in configsettings.java(counted in utf-8 byte length)
_**(WONT AFFECT ORIGINAL ITEM,ONLY AFFECT DISPLAY OF THE ITEM IN BOOKS BY TEXT COMPONENTS**_