### PR TITLE
SQL語法修正+bug修正

### DIFF
--- a/src/me/Cutiemango/MangoQuest/manager/database/DatabaseManager.java
+++ b/src/me/Cutiemango/MangoQuest/manager/database/DatabaseManager.java
@@ -65,7 +65,7 @@ public class DatabaseManager
 						"    `Version` BIGINT(20) NOT NULL DEFAULT '0' COMMENT '任務版本'," +
 						"    `TakeStamp` BIGINT(20) NOT NULL DEFAULT '0' COMMENT '任務接取時間'," +
 						"    `QuestObjectProgress` VARCHAR(1023) NOT NULL DEFAULT '' COMMENT '任務物件進度資料'," +
-						"    PRIMARY KEY (`QPDID`)," +
+						"    PRIMARY KEY (`PDID`,`QuestID`)," +
 						"    UNIQUE INDEX `QPDID` (`QPDID`)" +
 						") " +
 						"ENGINE=InnoDB " +
@@ -84,7 +84,7 @@ public class DatabaseManager
 						"    `FinishedTimes` INT(11) NOT NULL COMMENT '完成次數'," +
 						"    `LastFinishTime` BIGINT(20) NOT NULL DEFAULT '0' COMMENT '上次完成時間'," +
 						"    `RewardTaken` INT(11) NOT NULL DEFAULT 0 COMMENT '是否已領取獎勵'," +
-						"    PRIMARY KEY (`FQID`)," +
+						"    PRIMARY KEY (`PDID`,`QuestID`)," +
 						"    UNIQUE INDEX `FQID` (`FQID`)" +
 						") " +
 						"ENGINE=InnoDB " +
@@ -101,7 +101,7 @@ public class DatabaseManager
 						"	`PDID` INT(11) NOT NULL COMMENT '玩家資料流水號'," +
 						"	`NPC` INT(11) NOT NULL COMMENT 'NPC代號(ID)'," +
 						"	`FriendPoint` INT(11) DEFAULT '0' NOT NULL COMMENT '好感度'," +
-						"	PRIMARY KEY (`FPID`)," +
+						"	PRIMARY KEY (`PDID`,`NPC`)," +
 						"	UNIQUE INDEX `FPID` (`FPID`)" +
 						") " +
 						"ENGINE=InnoDB " +
@@ -117,7 +117,7 @@ public class DatabaseManager
 						"	`FCID` INT(11) NOT NULL AUTO_INCREMENT COMMENT '完成對話流水號'," +
 						"	`PDID` INT(11) NOT NULL COMMENT '玩家資料流水號'," +
 						"	`ConvID` VARCHAR(128) NOT NULL DEFAULT '' COMMENT '對話名稱(ID)'," +
-						"	PRIMARY KEY (`FCID`)," +
+						"	PRIMARY KEY (`PDID`,`ConvID`)," +
 						"	UNIQUE INDEX `FCID` (`FCID`)" +
 						") " +
 						"ENGINE=InnoDB " +

--- a/src/me/Cutiemango/MangoQuest/manager/database/DatabaseSaver.java
+++ b/src/me/Cutiemango/MangoQuest/manager/database/DatabaseSaver.java
@@ -19,10 +19,10 @@ public class DatabaseSaver
 	/**
 	 * Saves the entire player data into the database.
 	 * PDID is required.
-	 *
 	 * @param pd player's data to be saved
 	 */
-	public static void savePlayerData(QuestPlayerData pd) {
+	public static void savePlayerData(QuestPlayerData pd)
+	{
 		int PDID = pd.getPDID();
 		saveLoginData(pd.getPlayer());
 
@@ -33,115 +33,144 @@ public class DatabaseSaver
 
 		removeFinishedQuests(pd.getProgresses(), PDID);
 	}
-
-	public static void saveLoginData(Player p) {
+	
+	public static void saveLoginData(Player p)
+	{
 		Connection conn = DatabaseManager.getConnection();
-		try (PreparedStatement stmt = conn.prepareStatement(
-				"INSERT INTO mq_playerdata (UUID, LastKnownID) values (?, ?)" + " ON DUPLICATE KEY UPDATE mq_playerdata set LastKnownID = ? WHERE UUID = ?")) {
-
-			stmt.setNString(1, p.getUniqueId().toString());
-			stmt.setNString(2, p.getName());
-			stmt.setNString(3, p.getName());
-			stmt.setNString(4, p.getUniqueId().toString());
-			stmt.execute();
-		} catch (SQLException e) {
+		try(PreparedStatement insertupdate = conn.prepareStatement("INSERT INTO mq_playerdata (UUID, LastKnownID) values (?, ?)"
+				+ " ON DUPLICATE KEY UPDATE LastKnownID = ? ");)
+		{
+			
+			insertupdate.setNString(1, p.getUniqueId().toString());
+			insertupdate.setNString(2, p.getName());
+			insertupdate.setNString(3, p.getName());
+			insertupdate.execute();
+	
+		}
+		catch (SQLException e)
+		{
 			e.printStackTrace();
 		}
 	}
 
-	private static void saveFriendPoint(int npc, int friendPoint, int PDID) {
+
+	
+	private static void saveFriendPoint(int npc, int friendPoint, int PDID)
+	{
 		Connection conn = DatabaseManager.getConnection();
-		try (PreparedStatement stmt = conn.prepareStatement(
-				"INSERT INTO mq_friendpoint (PDID, NPC, FriendPoint) values (?, ?, ?)" + " ON DUPLICATE KEY UPDATE mq_friendpoint set FriendPoint = ? WHERE PDID = ? AND NPC = ?")) {
-			stmt.setInt(1, PDID);
-			stmt.setInt(2, npc);
-			stmt.setInt(3, friendPoint);
-			stmt.setInt(4, friendPoint);
-			stmt.setInt(5, PDID);
-			stmt.setInt(6, npc);
-			stmt.execute();
-		} catch (SQLException e) {
+		try(PreparedStatement insertupdate = conn.prepareStatement("INSERT INTO mq_friendpoint (PDID, NPC, FriendPoint) values (?, ?, ?)"
+				+ " ON DUPLICATE KEY UPDATE FriendPoint = ? "))
+		{
+			insertupdate.setInt(1, PDID);
+			insertupdate.setInt(2, npc);
+			insertupdate.setInt(3, friendPoint);
+			insertupdate.setInt(4, friendPoint);
+			insertupdate.execute();
+			
+		}
+		catch (SQLException e)
+		{
 			e.printStackTrace();
 		}
 	}
 
-	private static void saveFinishedConversation(String convID, int PDID) {
+	private static void saveFinishedConversation(String convID, int PDID)
+	{
 		Connection conn = DatabaseManager.getConnection();
-		try {
+		try
+		{
 			PreparedStatement select = conn.prepareStatement("SELECT * FROM mq_finishedconv WHERE PDID = ? AND ConvID = ?");
 			select.setInt(1, PDID);
 			select.setNString(2, convID);
 
-			if (!select.executeQuery().next()) {
+			if (!select.executeQuery().next())
+			{
 				PreparedStatement insert = conn.prepareStatement("INSERT INTO mq_finishedconv (PDID, ConvID) values (?, ?)");
 				insert.setInt(1, PDID);
 				insert.setNString(2, convID);
 				insert.execute();
 			}
-		} catch (SQLException e) {
+		}
+		catch (SQLException e)
+		{
 			e.printStackTrace();
 		}
 	}
 
-	private static void saveQuestProgress(QuestProgress questProgress, int PDID) {
+
+	
+	private static void saveQuestProgress(QuestProgress questProgress, int PDID)
+	{
 		Connection conn = DatabaseManager.getConnection();
-		try (PreparedStatement stmt = conn.prepareStatement(
-				"INSERT INTO mq_questprogress (PDID, QuestID, QuestObjectProgress, QuestStage, TakeStamp, Version) values (?, ?, ?, ?, ?, ?) " + "ON DUPLICATE KEY UPDATE mq_questprogress set QuestObjectProgress = ?, QuestStage = ?, Version = ? WHERE PDID = ? AND QuestID = ?")) {
-			stmt.setInt(1, PDID);
-			stmt.setNString(2, questProgress.getQuest().getInternalID());
-			stmt.setNString(3, JSONSerializer.jsonSerialize(questProgress.getCurrentObjects()));
-			stmt.setInt(4, questProgress.getCurrentStage());
-			stmt.setLong(5, questProgress.getTakeTime());
-			stmt.setLong(6, questProgress.getQuest().getVersion().getTimeStamp());
-			stmt.setNString(7, JSONSerializer.jsonSerialize(questProgress.getCurrentObjects()));
-			stmt.setInt(8, questProgress.getCurrentStage());
-			stmt.setLong(9, questProgress.getQuest().getVersion().getTimeStamp());
-			stmt.setInt(10, PDID);
-			stmt.setNString(11, questProgress.getQuest().getInternalID());
-			stmt.execute();
-		} catch (SQLException e) {
+		try(PreparedStatement insertupdate = conn.prepareStatement("INSERT INTO mq_questprogress (PDID, QuestID, QuestObjectProgress, QuestStage, TakeStamp, Version) values (?, ?, ?, ?, ?, ?) "
+				+ "ON DUPLICATE KEY UPDATE QuestObjectProgress = ?, QuestStage = ?, Version = ? ");)
+		{
+			insertupdate.setInt(1, PDID);
+			insertupdate.setNString(2, questProgress.getQuest().getInternalID());
+			insertupdate.setNString(3, JSONSerializer.jsonSerialize(questProgress.getCurrentObjects()));
+			insertupdate.setInt(4, questProgress.getCurrentStage());
+			insertupdate.setLong(5, questProgress.getTakeTime());
+			insertupdate.setLong(6, questProgress.getQuest().getVersion().getTimeStamp());
+		    insertupdate.setNString(7, JSONSerializer.jsonSerialize(questProgress.getCurrentObjects()));
+			insertupdate.setInt(8, questProgress.getCurrentStage());
+			insertupdate.setLong(9, questProgress.getQuest().getVersion().getTimeStamp());
+			insertupdate.execute();
+			
+		}
+		catch (SQLException e)
+		{
 			e.printStackTrace();
 		}
 	}
 
-	private static void removeFinishedQuests(Set<QuestProgress> progresses, int PDID) {
+	private static void removeFinishedQuests(Set<QuestProgress> progresses, int PDID)
+	{
 		Connection conn = DatabaseManager.getConnection();
-		try {
+		try
+		{
 			PreparedStatement select = conn.prepareStatement("SELECT * FROM mq_questprogress WHERE PDID = ?");
 			select.setInt(1, PDID);
 			ResultSet results = select.executeQuery();
-			while (results.next()) {
+			while (results.next())
+			{
 				String questID = results.getString("QuestID");
-				if (progresses.stream().noneMatch(questProgress -> questProgress.getQuest().getInternalID().equals(questID))) {
+				if (progresses.stream().noneMatch(questProgress -> questProgress.getQuest().getInternalID().equals(questID)))
+				{
 					PreparedStatement delete = conn.prepareStatement("DELETE FROM mq_questprogress WHERE PDID = ? AND QuestID = ?");
 					delete.setInt(1, PDID);
 					delete.setNString(2, questID);
 					delete.execute();
 				}
 			}
-		} catch (SQLException e) {
+		}
+		catch (SQLException e)
+		{
 			e.printStackTrace();
 		}
 	}
 
-	private static void saveFinishedQuest(QuestFinishData questData, int PDID) {
+	
+	private static void saveFinishedQuest(QuestFinishData questData, int PDID)
+	{
 		Connection conn = DatabaseManager.getConnection();
-		try (PreparedStatement stmt = conn.prepareStatement(
-				"INSERT INTO mq_finishedquest (PDID, QuestID, LastFinishTime, FinishedTimes, RewardTaken) values (?, ?, ?, ?, ?) " + "ON DUPLICATE KEY UPDATE mq_finishedquest set FinishedTimes = ?, RewardTaken = ?, LastFinishTime = ? WHERE PDID = ? AND QuestID = ?")) {
-			stmt.setInt(1, PDID);
-			stmt.setNString(2, questData.getQuest().getInternalID());
-			stmt.setLong(3, questData.getLastFinish());
-			stmt.setInt(4, questData.getFinishedTimes());
-			stmt.setBoolean(5, questData.isRewardTaken());
-			stmt.setInt(6, questData.getFinishedTimes());
-			stmt.setInt(7, questData.isRewardTaken() ? 1 : 0);
-			stmt.setLong(8, questData.getLastFinish());
-			stmt.setInt(9, PDID);
-			stmt.setNString(10, questData.getQuest().getInternalID());
-			stmt.execute();
-
-		} catch (SQLException e) {
+		try(PreparedStatement insertupdate = conn.prepareStatement("INSERT INTO mq_finishedquest (PDID, QuestID, LastFinishTime, FinishedTimes, RewardTaken) values (?, ?, ?, ?, ?) "
+				+ "ON DUPLICATE KEY UPDATE FinishedTimes = ?, RewardTaken = ?, LastFinishTime = ?");)
+		{
+			insertupdate.setInt(1, PDID);
+			insertupdate.setNString(2, questData.getQuest().getInternalID());
+			insertupdate.setLong(3, questData.getLastFinish());
+			insertupdate.setInt(4, questData.getFinishedTimes());
+			insertupdate.setBoolean(5, questData.isRewardTaken());
+			insertupdate.setInt(6, questData.getFinishedTimes());
+			insertupdate.setInt(7, questData.isRewardTaken() ? 1 : 0);
+			insertupdate.setLong(8, questData.getLastFinish());
+			insertupdate.execute();
+		
+		}
+		catch (SQLException e)
+		{
 			e.printStackTrace();
 		}
 	}
+	
 }


### PR DESCRIPTION
This is the same pull request as the pull request i opened few hours ago,except i also fixed the database manager.
This PR fixes existing syntax error(apologies for that,the sql syntax checker misleaded me)
the SQL syntax now perfectly works.
But the **real problem** is
### PRIMARY KEY
To be compatible with the duplicate key check,the primary key must be identifier for players.Unfortunately, the existing primary key is FCID,FQID which are used purely for sorting.This fails the ON DUPLICATE KEY check horribly.
To fix this,i made the primary key more like primary key(two fields containing PDID and another field depending on the table)
This should be the guaranteed fix.
apologies for being careless